### PR TITLE
Basic Item Endpoints

### DIFF
--- a/app/controllers/api/v1/items/random_controller.rb
+++ b/app/controllers/api/v1/items/random_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Items::RandomController < ApplicationController
+  def show
+    render json: ItemSerializer.new(Item.random)
+  end
+end

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::Items::SearchController < ApplicationController
+  def index
+    render json: ItemSerializer.new(Item.search_all(search_params.to_h))
+  end
+
+  def show
+    render json: ItemSerializer.new(Item.search(search_params.to_h))
+  end
+
+  private
+
+  def search_params
+    params.permit(:id, :name, :description, :unit_price, :merchant_id, :created_at, :updated_at)
+  end
+end

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -10,6 +10,9 @@ class Api::V1::Items::SearchController < ApplicationController
   private
 
   def search_params
+    if params[:unit_price]
+      params[:unit_price] = (params[:unit_price].to_f * 100).round(0).to_i
+    end
     params.permit(:id, :name, :description, :unit_price, :merchant_id, :created_at, :updated_at)
   end
 end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::ItemsController < ApplicationController
+  def index
+    render json: ItemSerializer.new(Item.all)
+  end
+
+  def show
+    render json: ItemSerializer.new(Item.find(params[:id]))
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,6 +9,10 @@ class ApplicationRecord < ActiveRecord::Base
     where(search_hash).order(:id)
   end
 
+  def self.random
+    find(self.pluck(:id).sample)
+  end
+
   private
 
   def self.date_criteria(date)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,14 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  def self.search(search_hash)
+    search_all(search_hash).first
+  end
+
+  def self.search_all(search_hash)
+    where(search_hash)
+  end
+
   private
 
   def self.date_criteria(date)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,7 +6,7 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def self.search_all(search_hash)
-    where(search_hash)
+    where(search_hash).order(:id)
   end
 
   private

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -5,10 +5,6 @@ class Merchant < ApplicationRecord
 
   validates_presence_of :name
 
-  def self.random
-    find(self.pluck(:id).sample)
-  end
-
   def self.top_x_by_revenue(limit)
     self.select(:id, :name)
         .select("SUM(invoice_items.quantity * invoice_items.unit_price) AS revenue")

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -5,14 +5,6 @@ class Merchant < ApplicationRecord
 
   validates_presence_of :name
 
-  def self.search(search_hash)
-    search_all(search_hash).first
-  end
-
-  def self.search_all(search_hash)
-    where(search_hash)
-  end
-
   def self.random
     find(self.pluck(:id).sample)
   end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,4 +1,8 @@
 class ItemSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :id, :name, :description, :unit_price, :merchant_id
+  attributes :id, :name, :description, :merchant_id
+
+  attributes :unit_price do |item|
+    '%.2f' % (item.unit_price / 100.00)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       namespace :items do
         get "/find", to: "search#show"
         get "/find_all", to: "search#index"
+        get "/random", to: "random#show"
       end
 
       resources :items, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,11 @@ Rails.application.routes.draw do
         end
       end
 
+      namespace :items do
+        get "/find", to: "search#show"
+        get "/find_all", to: "search#index"
+      end
+
       resources :items, only: [:index, :show]
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
           resources :invoices, only: [:index]
         end
       end
+
+      resources :items, only: [:index, :show]
     end
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :item do
-    name { "MyString" }
-    description { "MyText" }
-    unit_price { 1 }
+    sequence(:name) { |n| "Item Name #{n}" }
+    sequence(:description) { |n| "Item Description #{n}" }
+    sequence(:unit_price) { |n| 500 + n }
     association :merchant, factory: :merchant
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,4 +73,8 @@ RSpec.configure do |config|
   def parse_api_1point0_response
     JSON.parse(response.body)["data"]
   end
+
+  def format_price(price)
+    '%.2f' % (price / 100.00)
+  end
 end

--- a/spec/requests/api/v1/items/random_controller_spec.rb
+++ b/spec/requests/api/v1/items/random_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Items::RandomController do
+  describe "GET #show" do
+    before(:each) do
+      @i1, @i2, @i3 =  create_list(:item, 3)
+      get "/api/v1/items/random"
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "returns a random item" do
+      item_json = parse_api_1point0_response
+
+      expect(item_json["attributes"]["name"]).to satisfy { |actual_name| [@i1.name, @i2.name, @i3.name].include?(actual_name) }
+    end
+  end
+end

--- a/spec/requests/api/v1/items/search_controller_spec.rb
+++ b/spec/requests/api/v1/items/search_controller_spec.rb
@@ -1,0 +1,253 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Items::SearchController do
+  describe "GET #index" do
+    before(:each) do
+      @count = 5
+      @name = "Bob's Invention"
+      @description = "Bob's Great Invention"
+      @unit_price = 19999
+      @merchant = create(:merchant)
+      @first_item = create(:item, name: @name, description: @description, unit_price: @unit_price, merchant: @merchant)
+      @sec_item = create(:item, name: @name, description: @description, unit_price: @unit_price, merchant: @merchant)
+      create_list(:item, @count - 2)
+    end
+
+    it "returns http success" do
+      get "/api/v1/items/find_all?name=#{@name}"
+      expect(response).to have_http_status(:success)
+    end
+
+    it "outputs data for all items with a particular name" do
+      get "/api/v1/items/find_all?name=#{@name}"
+      items = parse_api_1point0_response
+
+      expect(items.class).to eq(Array)
+      expect(items.count).to eq(2)
+
+      expected_first =  {
+        "id" => @first_item.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => @first_item.id,
+          "name" => @first_item.name,
+          "description" => @first_item.description,
+          "unit_price" => format_price(@first_item.unit_price),
+          "merchant_id" => @first_item.merchant_id
+        }
+      }
+      expect(items.first).to eq(expected_first)
+    end
+
+    it "outputs data for all items with a particular description" do
+      get "/api/v1/items/find_all?description=#{@description}"
+      items = parse_api_1point0_response
+
+      expect(items.class).to eq(Array)
+      expect(items.count).to eq(2)
+
+      expected_first =  {
+        "id" => @first_item.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => @first_item.id,
+          "name" => @first_item.name,
+          "description" => @first_item.description,
+          "unit_price" => format_price(@first_item.unit_price),
+          "merchant_id" => @first_item.merchant_id
+        }
+      }
+      expect(items.first).to eq(expected_first)
+    end
+
+    xit "outputs data for all items with a particular unit_price" do
+      get "/api/v1/items/find_all?unit_price=#{@unit_price}"
+      items = parse_api_1point0_response
+
+      expect(items.class).to eq(Array)
+      expect(items.count).to eq(2)
+
+      expected_first =  {
+        "id" => @first_item.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => @first_item.id,
+          "name" => @first_item.name,
+          "description" => @first_item.description,
+          "unit_price" => format_price(@first_item.unit_price),
+          "merchant_id" => @first_item.merchant_id
+        }
+      }
+      expect(items.first).to eq(expected_first)
+    end
+
+    xit "outputs data for all items with a particular created_at" do
+      get "/api/v1/items/find_all?created_at=#{@created_at}"
+      items = parse_api_1point0_response
+
+      expect(items.class).to eq(Array)
+      expect(items.count).to eq(2)
+
+      expected_first =  {
+        "id" => @first_item.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => @first_item.id,
+          "name" => @first_item.name,
+          "description" => @first_item.description,
+          "unit_price" => format_price(@first_item.unit_price),
+          "merchant_id" => @first_item.merchant_id
+        }
+      }
+      expect(items.first).to eq(expected_first)
+    end
+
+    xit "outputs data for all items with a particular updated_at" do
+      get "/api/v1/items/find_all?updated_at=#{@updated_at}"
+      items = parse_api_1point0_response
+
+      expect(items.class).to eq(Array)
+      expect(items.count).to eq(2)
+
+      expected_first =  {
+        "id" => @first_item.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => @first_item.id,
+          "name" => @first_item.name,
+          "description" => @first_item.description,
+          "unit_price" => format_price(@first_item.unit_price),
+          "merchant_id" => @first_item.merchant_id
+        }
+      }
+      expect(items.first).to eq(expected_first)
+    end
+  end
+
+  describe "GET #show" do
+    before(:each) do
+      @count = 3
+      @first_item = create(:item, name: "Bob", description: "Bob's Great Invention", unit_price: 19999, created_at: "2012-03-27 14:53:59 UTC", updated_at: "2013-03-27 14:53:59 UTC")
+      @other_items =  create_list(:item, @count - 1, created_at: "2014-03-27 14:53:59 UTC", updated_at: "2015-03-27 14:53:59 UTC")
+    end
+
+    it "returns http success" do
+      get "/api/v1/items/find?id=#{@first_item.id}"
+      expect(response).to have_http_status(:success)
+    end
+
+    it "finds an item by id" do
+      item_resource = @other_items.first
+      get "/api/v1/items/find?id=#{item_resource.id}"
+      item_json = parse_api_1point0_response
+
+      expected_hash =  {
+        "id" => item_resource.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => item_resource.id,
+          "name" => item_resource.name,
+          "description" => item_resource.description,
+          "unit_price" => format_price(item_resource.unit_price),
+          "merchant_id" => item_resource.merchant_id
+        }
+      }
+      expect(item_json).to eq(expected_hash)
+    end
+
+    it "finds an item by name" do
+      item_resource = @other_items.first
+      get "/api/v1/items/find?name=#{item_resource.name}"
+      item_json = parse_api_1point0_response
+
+      expected_hash =  {
+        "id" => item_resource.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => item_resource.id,
+          "name" => item_resource.name,
+          "description" => item_resource.description,
+          "unit_price" => format_price(item_resource.unit_price),
+          "merchant_id" => item_resource.merchant_id
+        }
+      }
+      expect(item_json).to eq(expected_hash)
+    end
+
+    it "finds an item by description" do
+      item_resource = @other_items.first
+      get "/api/v1/items/find?description=#{item_resource.description}"
+      item_json = parse_api_1point0_response
+
+      expected_hash =  {
+        "id" => item_resource.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => item_resource.id,
+          "name" => item_resource.name,
+          "description" => item_resource.description,
+          "unit_price" => format_price(item_resource.unit_price),
+          "merchant_id" => item_resource.merchant_id
+        }
+      }
+      expect(item_json).to eq(expected_hash)
+    end
+
+    xit "finds an item by unit_price" do
+      item_resource = @other_items.first
+      get "/api/v1/items/find?unit_price=#{item_resource.unit_price}"
+      item_json = parse_api_1point0_response
+
+      expected_hash =  {
+        "id" => item_resource.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => item_resource.id,
+          "name" => item_resource.name,
+          "description" => item_resource.description,
+          "unit_price" => format_price(item_resource.unit_price),
+          "merchant_id" => item_resource.merchant_id
+        }
+      }
+      expect(item_json).to eq(expected_hash)
+    end
+
+    it "finds an item by created_at" do
+      item_resource = @other_items.first
+      get "/api/v1/items/find?created_at=#{item_resource.created_at}"
+      item_json = parse_api_1point0_response
+
+      expected_hash =  {
+        "id" => item_resource.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => item_resource.id,
+          "name" => item_resource.name,
+          "description" => item_resource.description,
+          "unit_price" => format_price(item_resource.unit_price),
+          "merchant_id" => item_resource.merchant_id
+        }
+      }
+      expect(item_json).to eq(expected_hash)
+    end
+
+    it "finds an item by updated_at" do
+      item_resource = @other_items.first
+      get "/api/v1/items/find?updated_at=#{item_resource.updated_at}"
+      item_json = parse_api_1point0_response
+
+      expected_hash =  {
+        "id" => item_resource.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => item_resource.id,
+          "name" => item_resource.name,
+          "description" => item_resource.description,
+          "unit_price" => format_price(item_resource.unit_price),
+          "merchant_id" => item_resource.merchant_id
+        }
+      }
+      expect(item_json).to eq(expected_hash)
+    end
+  end
+end

--- a/spec/requests/api/v1/items/search_controller_spec.rb
+++ b/spec/requests/api/v1/items/search_controller_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe Api::V1::Items::SearchController do
       @description = "Bob's Great Invention"
       @unit_price = 19999
       @merchant = create(:merchant)
-      @first_item = create(:item, name: @name, description: @description, unit_price: @unit_price, merchant: @merchant)
-      @sec_item = create(:item, name: @name, description: @description, unit_price: @unit_price, merchant: @merchant)
+      @created_at = "2012-03-27 14:53:59 UTC"
+      @updated_at = "2013-03-27 14:53:59 UTC"
+      @first_item, @sec_item = create_list(:item, 2, name: @name, description: @description, unit_price: @unit_price, merchant: @merchant, created_at: @created_at, updated_at: @updated_at)
       create_list(:item, @count - 2)
     end
 
@@ -60,8 +61,8 @@ RSpec.describe Api::V1::Items::SearchController do
       expect(items.first).to eq(expected_first)
     end
 
-    xit "outputs data for all items with a particular unit_price" do
-      get "/api/v1/items/find_all?unit_price=#{@unit_price}"
+    it "outputs data for all items with a particular unit_price" do
+      get "/api/v1/items/find_all?unit_price=#{format_price(@unit_price)}"
       items = parse_api_1point0_response
 
       expect(items.class).to eq(Array)
@@ -81,7 +82,7 @@ RSpec.describe Api::V1::Items::SearchController do
       expect(items.first).to eq(expected_first)
     end
 
-    xit "outputs data for all items with a particular created_at" do
+    it "outputs data for all items with a particular created_at" do
       get "/api/v1/items/find_all?created_at=#{@created_at}"
       items = parse_api_1point0_response
 
@@ -102,7 +103,7 @@ RSpec.describe Api::V1::Items::SearchController do
       expect(items.first).to eq(expected_first)
     end
 
-    xit "outputs data for all items with a particular updated_at" do
+    it "outputs data for all items with a particular updated_at" do
       get "/api/v1/items/find_all?updated_at=#{@updated_at}"
       items = parse_api_1point0_response
 
@@ -193,9 +194,9 @@ RSpec.describe Api::V1::Items::SearchController do
       expect(item_json).to eq(expected_hash)
     end
 
-    xit "finds an item by unit_price" do
+    it "finds an item by unit_price" do
       item_resource = @other_items.first
-      get "/api/v1/items/find?unit_price=#{item_resource.unit_price}"
+      get "/api/v1/items/find?unit_price=#{format_price(item_resource.unit_price)}"
       item_json = parse_api_1point0_response
 
       expected_hash =  {

--- a/spec/requests/api/v1/items_controller_spec.rb
+++ b/spec/requests/api/v1/items_controller_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ItemsController do
+  describe "GET #index" do
+    before(:each) do
+      @count = 5
+      @first_item = create(:item)
+      create_list(:item, @count - 1)
+      get '/api/v1/items'
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "outputs data for all items" do
+      items = parse_api_1point0_response
+
+      expect(items.class).to eq(Array)
+      expect(items.count).to eq(@count)
+
+      expected_price = '%.2f' % (@first_item.unit_price / 100.00)
+
+      expected_first =  {
+        "id" => @first_item.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => @first_item.id,
+          "name" => @first_item.name,
+          "description" => @first_item.description,
+          "unit_price" => expected_price,
+          "merchant_id" => @first_item.merchant_id
+        }
+      }
+      expect(items.first).to eq(expected_first)
+    end
+  end
+
+  describe "GET #show" do
+    before(:each) do
+      @count = 5
+      @first_item = create(:item)
+      @other_items =  create_list(:item, @count - 1)
+    end
+
+    it "returns http success" do
+      get "/api/v1/items/#{@first_item.id}"
+      expect(response).to have_http_status(:success)
+    end
+
+    it "outputs data for a single item" do
+      get "/api/v1/items/#{@first_item.id}"
+      item = parse_api_1point0_response
+
+      expect(item.class).to eq(Hash)
+
+      expected_price = '%.2f' % (@first_item.unit_price / 100.00)
+
+      expected_hash =  {
+        "id" => @first_item.id.to_s,
+        "type" => "item",
+        "attributes" => {
+          "id" => @first_item.id,
+          "name" => @first_item.name,
+          "description" => @first_item.description,
+          "unit_price" => expected_price,
+          "merchant_id" => @first_item.merchant_id
+        }
+      }
+      expect(item).to eq(expected_hash)
+    end
+  end
+end

--- a/spec/requests/api/v1/items_controller_spec.rb
+++ b/spec/requests/api/v1/items_controller_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe Api::V1::ItemsController do
       expect(items.class).to eq(Array)
       expect(items.count).to eq(@count)
 
-      expected_price = '%.2f' % (@first_item.unit_price / 100.00)
-
       expected_first =  {
         "id" => @first_item.id.to_s,
         "type" => "item",
@@ -28,7 +26,7 @@ RSpec.describe Api::V1::ItemsController do
           "id" => @first_item.id,
           "name" => @first_item.name,
           "description" => @first_item.description,
-          "unit_price" => expected_price,
+          "unit_price" => format_price(@first_item.unit_price),
           "merchant_id" => @first_item.merchant_id
         }
       }
@@ -54,8 +52,6 @@ RSpec.describe Api::V1::ItemsController do
 
       expect(item.class).to eq(Hash)
 
-      expected_price = '%.2f' % (@first_item.unit_price / 100.00)
-
       expected_hash =  {
         "id" => @first_item.id.to_s,
         "type" => "item",
@@ -63,7 +59,7 @@ RSpec.describe Api::V1::ItemsController do
           "id" => @first_item.id,
           "name" => @first_item.name,
           "description" => @first_item.description,
-          "unit_price" => expected_price,
+          "unit_price" => format_price(@first_item.unit_price),
           "merchant_id" => @first_item.merchant_id
         }
       }

--- a/spec/requests/api/v1/merchants/items_controller_spec.rb
+++ b/spec/requests/api/v1/merchants/items_controller_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe Api::V1::Merchants::ItemsController do
       expect(items.class).to eq(Array)
       expect(items.count).to eq(3)
 
-      expected_price = '%.2f' % (@i1.unit_price / 100.00)
-
       expected_first =  {
         "id" => @i1.id.to_s,
         "type" => "item",
@@ -29,7 +27,7 @@ RSpec.describe Api::V1::Merchants::ItemsController do
           "id" => @i1.id,
           "name" => @i1.name,
           "description" => @i1.description,
-          "unit_price" => expected_price,
+          "unit_price" => format_price(@i1.unit_price),
           "merchant_id" => @i1.merchant_id
         }
       }

--- a/spec/requests/api/v1/merchants/items_controller_spec.rb
+++ b/spec/requests/api/v1/merchants/items_controller_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Api::V1::Merchants::ItemsController do
       expect(items.class).to eq(Array)
       expect(items.count).to eq(3)
 
+      expected_price = '%.2f' % (@i1.unit_price / 100.00)
+
       expected_first =  {
         "id" => @i1.id.to_s,
         "type" => "item",
@@ -27,7 +29,7 @@ RSpec.describe Api::V1::Merchants::ItemsController do
           "id" => @i1.id,
           "name" => @i1.name,
           "description" => @i1.description,
-          "unit_price" => @i1.unit_price,
+          "unit_price" => expected_price,
           "merchant_id" => @i1.merchant_id
         }
       }

--- a/spec/requests/api/v1/merchants_controller_spec.rb
+++ b/spec/requests/api/v1/merchants_controller_spec.rb
@@ -59,21 +59,5 @@ RSpec.describe Api::V1::MerchantsController do
       }
       expect(merchant).to eq(expected_hash)
     end
-
-    it "finds by id" do
-      merchant_resource = @other_merchants.first
-      get "/api/v1/merchants/find?id=#{merchant_resource.id}"
-      merchant_json = parse_api_1point0_response
-
-      expected_hash =  {
-        "id" => merchant_resource.id.to_s,
-        "type" => "merchant",
-        "attributes" => {
-          "id" => merchant_resource.id,
-          "name" => merchant_resource.name
-        }
-      }
-      expect(merchant_json).to eq(expected_hash)
-    end
   end
 end


### PR DESCRIPTION
This branch...
 - Updates `ItemSerializer` (formats `unit_price` as a float)
 - Adds basic `Item` endpoints
    - `ItemsController#index` & `#show`
    - `Items::SearchController#index` & `#show`
    - `Items::RandomController#show`
 - Moves `::search`, `::search_all`, & `::random` from `Merchant` to `ApplicationRecord`
 - Makes smarter `ItemSerializer` using sequences
 - Adds `format_price` helper method in `rails_helper`